### PR TITLE
feat: add send the my pick data

### DIFF
--- a/controllers/myPick.js
+++ b/controllers/myPick.js
@@ -1,0 +1,31 @@
+const mongoose = require("mongoose");
+const { ObjectId } = mongoose.Types;
+const createError = require("http-errors");
+
+const myPickService = require("../services/myPick");
+
+exports.getMyPicks = async (req, res, next) => {
+  try {
+    const { userId } = req.params;
+
+    if (!ObjectId.isValid(userId)) {
+      res.status(400).json({
+        result: "fail",
+        error: {
+          message: "Not Valid ObjectId",
+        },
+      });
+
+      return;
+    }
+
+    const picks = await myPickService.getPicks(userId);
+
+    res.json({
+      result: "success",
+      data: picks,
+    });
+  } catch (err) {
+    next(createError(500, "Invalid Server Error"));
+  }
+};

--- a/models/Plan.js
+++ b/models/Plan.js
@@ -12,7 +12,7 @@ const PlanSchema = new Schema({
   },
   placeLocation: [
     {
-      type: String,
+      type: Number,
     },
   ],
   date: {

--- a/routes/users.js
+++ b/routes/users.js
@@ -1,9 +1,11 @@
 const express = require("express");
 const router = express.Router();
 
-const planListController = require("../controllers/planList");
 const verifyToken = require("../routes/middlewares/verifyToken");
+const planListController = require("../controllers/planList");
+const myPickController = require("../controllers/myPick");
 
 router.get("/:userId/planlist", verifyToken, planListController.getPlanList);
+router.get("/:userId/mypick", verifyToken, myPickController.getMyPicks);
 
 module.exports = router;

--- a/services/myPick.js
+++ b/services/myPick.js
@@ -1,0 +1,22 @@
+const Pick = require("../models/Pick");
+const User = require("../models/User");
+
+exports.getPicks = async (userId) => {
+  const picks = {};
+
+  const pick = await User.findById(userId).populate("picks");
+
+  pick.picks.map((pick) => {
+    picks[pick._id] = {
+      author: pick.author,
+      name: pick.name,
+      address: pick.address,
+      rating: pick.rating,
+      type: pick.type,
+      image: pick.image,
+      location: pick.location,
+    };
+  });
+
+  return picks;
+};


### PR DESCRIPTION
# [2] {My pick screen}

## 노션 칸반 링크
​- [My pick screen] (https://instinctive-maple-d7e.notion.site/Back-My-pick-Screen-8791e26d95764570b5a449bb9aae9913)

## 카드에서 구현 혹은 해결하려는 내용
- 접속한 user의 pick data를 client로 보내줌

