### PR TITLE
feat: add vote screen get logic

### DIFF
--- a/controllers/vote.js
+++ b/controllers/vote.js
@@ -29,3 +29,40 @@ exports.getVoteList = async (req, res, next) => {
     next(createError(500, "Invalid Server Error"));
   }
 };
+
+exports.getPicks = async (req, res, next) => {
+  try {
+    const { userId, planId } = req.params;
+
+    if (!ObjectId.isValid(userId)) {
+      res.status(400).json({
+        result: "fail",
+        error: {
+          message: "Not Valid ObjectId",
+        },
+      });
+
+      return;
+    }
+
+    if (!ObjectId.isValid(planId)) {
+      res.status(400).json({
+        result: "fail",
+        error: {
+          message: "Not Valid ObjectId",
+        },
+      });
+
+      return;
+    }
+
+    const picks = await voteService.getAllPick({ userId, planId });
+
+    res.json({
+      result: "success",
+      data: picks,
+    });
+  } catch (err) {
+    next(createError(500, "Invalid Server Error"));
+  }
+};

--- a/routes/users.js
+++ b/routes/users.js
@@ -23,5 +23,6 @@ router.post(
 router.post("/:userId/plan", verifyToken, makeAPlanController.createNewPlan);
 
 router.get("/:userId/plan/votelist", verifyToken, voteController.getVoteList);
+router.get("/:userId/plan/:planId/vote", verifyToken, voteController.getPicks);
 
 module.exports = router;

--- a/services/vote.js
+++ b/services/vote.js
@@ -1,3 +1,4 @@
+const Plan = require("../models/Plan");
 const User = require("../models/User");
 
 exports.getVotes = async (userId) => {
@@ -24,4 +25,37 @@ exports.getVotes = async (userId) => {
   });
 
   return votes;
+};
+
+exports.getAllPick = async ({ userId, planId }) => {
+  const friendsPicks = {};
+
+  const picks = await Plan.findById(planId).populate({
+    path: "friends",
+    populate: { path: "picks" },
+  });
+
+  const place = {
+    place: picks.place,
+    placeLocation: picks.placeLocation,
+  };
+
+  picks.friends.map((data) => {
+    data.picks.map((pick) => {
+      friendsPicks[pick._id] = {
+        author: pick.author,
+        name: pick.name,
+        address: pick.address,
+        rating: pick.rating,
+        type: pick.type,
+        image: pick.image,
+        location: pick.location,
+      };
+    });
+  });
+
+  return {
+    friendsPicks,
+    place,
+  };
 };


### PR DESCRIPTION
# [11] {Vote screen (GET)}

## 노션 칸반 링크
​- [Vote screen (GET)] (https://instinctive-maple-d7e.notion.site/Back-Vote-screen-GET-26de59fe21974b45ae3641b45409ceff)

## 카드에서 구현 혹은 해결하려는 내용
-  vote screen에서 요청한 친구들의 pick 정보 보내주기
