### PR TITLE
feat: vote result logic

### DIFF
--- a/controllers/vote.js
+++ b/controllers/vote.js
@@ -103,3 +103,57 @@ exports.savePickVote = async (req, res, next) => {
     next(createError(500, "Invalid Server Error"));
   }
 };
+
+exports.getVoteResult = async (req, res, next) => {
+  try {
+    const { userId, planId } = req.params;
+
+    if (!ObjectId.isValid(userId)) {
+      res.status(400).json({
+        result: "fail",
+        error: {
+          message: "Not Valid ObjectId",
+        },
+      });
+
+      return;
+    }
+
+    if (!ObjectId.isValid(planId)) {
+      res.status(400).json({
+        result: "fail",
+        error: {
+          message: "Not Valid ObjectId",
+        },
+      });
+
+      return;
+    }
+
+    const voteResult = await voteService.getResult(planId);
+
+    const totalPeople = voteResult.friends.length + 1;
+
+    if (voteResult.voting.length !== totalPeople) {
+      res.json({
+        result: "success",
+        data: "ongoing",
+      });
+
+      return;
+    }
+
+    if (voteResult.voting.length === totalPeople) {
+      await voteService.updateVoteState(planId);
+
+      res.json({
+        result: "success",
+        data: voteResult.voting,
+      });
+
+      return;
+    }
+  } catch (err) {
+    next(createError(500, "Invalid Server Error"));
+  }
+};

--- a/routes/users.js
+++ b/routes/users.js
@@ -29,4 +29,9 @@ router.post(
   verifyToken,
   voteController.savePickVote
 );
+router.get(
+  "/:userId/plan/:planId/vote/result",
+  verifyToken,
+  voteController.getVoteResult
+);
 module.exports = router;

--- a/services/vote.js
+++ b/services/vote.js
@@ -10,7 +10,7 @@ exports.getVotes = async (userId) => {
   });
 
   voteList.plans.map((plan) => {
-    if (!plan.isVoted) {
+    if (!plan.isFixed) {
       votes[plan._id] = {
         creator: plan.creator,
         place: plan.place,
@@ -68,4 +68,14 @@ exports.saveVote = async ({ userId, planId, vote }) => {
   await Plan.findByIdAndUpdate(planId, {
     $push: { voting: voteInfo },
   }).exec();
+};
+
+exports.getResult = async (planId) => {
+  const plan = await Plan.findById(planId);
+
+  return plan;
+};
+
+exports.updateVoteState = async (planId) => {
+  await Plan.findByIdAndUpdate(planId, { isVoted: true });
 };


### PR DESCRIPTION
# [11] {Vote Result}

## 노션 칸반 링크
​- [Vote Result] (https://instinctive-maple-d7e.notion.site/Back-Vote-result-2b652a3a065c400f81d3965b94565e77)

## 카드에서 구현 혹은 해결하려는 내용
-  vote reuslt에 대한 get 요쳥은 인원수 다 투표했을때 client로 보내짐
- isVoted는 true로 update
- 인원수 다 채워지지 않았을땐 진행중이라는 메세지 보냄

❗️voting에 저장되는 투표 결과의 객체 형태가 다루기 번거롭게 생겨서 리팩토링이 필요할 것 같음